### PR TITLE
[bug] 그룹 추가 페이지 상태 지속 버그

### DIFF
--- a/mobile/app/src/main/java/com/lacuc/pets/ui/manage/group/choose/ChooseGroupFragment.kt
+++ b/mobile/app/src/main/java/com/lacuc/pets/ui/manage/group/choose/ChooseGroupFragment.kt
@@ -40,6 +40,7 @@ class ChooseGroupFragment : DaggerFragment() {
             lifecycleOwner = viewLifecycleOwner
             vm = viewModel
         }
+        activityViewModel.gid = null
         return binding.root
     }
 


### PR DESCRIPTION
## :lock: 관련 이슈(닫을 이슈)
- (close #90) 

## :white_check_mark: 작업 내용
- 그룹 리스트 페이지의 뷰가 생성될 때 GID를 초기화하여 add 메뉴 선택 시 새 그룹 생성 상태를 가진다.

